### PR TITLE
Raise asset upload size limit to 50MB

### DIFF
--- a/assets/assetsmanager.go
+++ b/assets/assetsmanager.go
@@ -13,7 +13,7 @@ import (
 var tracer = otel.Tracer("github.com/International-Combat-Archery-Alliance/assets-api/assets")
 
 const (
-	maxUploadSize = 25 * 1024 * 1024 // 25MB
+	maxUploadSize = 50 * 1024 * 1024 // 50MB
 	uploadTTL     = 1 * time.Hour
 )
 

--- a/s3/storage.go
+++ b/s3/storage.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	MaxUploadSize = 25 * 1024 * 1024 // 25MB
+	MaxUploadSize = 50 * 1024 * 1024 // 50MB
 )
 
 var _ assets.StorageRepository = &Storage{}


### PR DESCRIPTION
Raises the max asset upload size from 25MB to 50MB to accommodate audio files like the radio interview recording (~41MB).

- `assetsmanager.go`: `maxUploadSize` 25MB → 50MB (new uploads + replacements)
- `storage.go`: `MaxUploadSize` 25MB → 50MB